### PR TITLE
Fix TypeError when dirs is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var Task = Elixir.Task;
 Elixir.extend('cleanup', function(dirs) {
   var default_dirs = ['public/css', 'public/js', 'public/build'];
   var custom_dirs = dirs || [];
-  var all_dirs = default_dirs.concat(dirs);
+  var all_dirs = default_dirs.concat(custom_dirs);
 
   new Task('cleanup', function(cb) {
     del(all_dirs, cb);


### PR DESCRIPTION
Fix incorrect `all_dirs` initialization and allows to call task without params as `cleanup()`. Right now it is working only with an array.